### PR TITLE
Add ingestion workflow and script using llama_index SDK

### DIFF
--- a/.github/workflows/ingest.yaml
+++ b/.github/workflows/ingest.yaml
@@ -1,0 +1,30 @@
+#parse all files using llama_index python sdk
+name: Ingest
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install llama-index
+
+      - name: Run ingestion script 
+        env:
+          LLAMA_INDEX_API_KEY: ${{ secrets.LLAMA_INDEX_API_KEY }}
+        run: |
+          mv README.md README.md.txt
+          python ingest.py

--- a/ingest.py
+++ b/ingest.py
@@ -1,0 +1,13 @@
+from llama_cloud_services import LlamaParse
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+LLAMA_INDEX_API_KEY = os.getenv("LLAMA_INDEX_API_KEY")
+
+parser = LlamaParse(
+    api_key = LLAMA_INDEX_API_KEY,
+)
+
+result = parser.parse("README.md.txt")   
+print(result)


### PR DESCRIPTION
This pull request introduces an automated workflow to parse files using the LlamaIndex Python SDK and includes the implementation of a corresponding ingestion script. The workflow is triggered on pushes to the `main` branch, and the script utilizes the LlamaIndex API to process the `README.md` file.

### Workflow Automation:
* [`.github/workflows/ingest.yaml`](diffhunk://#diff-6c33d2698872942f3739917f555680ef7bdebbb058fd85fa9e1b552c631d90ebR1-R30): Added a GitHub Actions workflow named "Ingest" that sets up a Python environment, installs the LlamaIndex SDK, and runs the ingestion script with the necessary API key.

### Ingestion Script:
* [`ingest.py`](diffhunk://#diff-abd34d324dcce966837adc13a98b86edc8f868d80e3ae601152f81a59c59734cR1-R13): Implemented a script that uses the `LlamaParse` class from the LlamaIndex SDK to parse the `README.md` file (renamed to `README.md.txt` during the workflow) and print the result. It also loads the API key from environment variables using the `dotenv` package.