### PR TITLE
Revert dependency installation from llama-cloud-services to llama-index

### DIFF
--- a/.github/workflows/ingest.yaml
+++ b/.github/workflows/ingest.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install llama-cloud-services
+          pip install llama-index
 
       - name: Run ingestion script 
         env:


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/ingest.yaml` file, replacing the dependency `llama-cloud-services` with `llama-index` in the workflow configuration.

* [`.github/workflows/ingest.yaml`](diffhunk://#diff-6c33d2698872942f3739917f555680ef7bdebbb058fd85fa9e1b552c631d90ebL23-R23): Updated the `Install dependencies` step to install `llama-index` instead of `llama-cloud-services`.