### PR TITLE
Update dependency installation in ingest.yaml to use llama-index…

### DIFF
--- a/.github/workflows/ingest.yaml
+++ b/.github/workflows/ingest.yaml
@@ -20,7 +20,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install llama-index
+          pip install llama-index-readers-code
+          pip install llama-index-readers-file
 
       - name: Run ingestion script 
         env:


### PR DESCRIPTION
This pull request updates the dependency installation process in the ingestion workflow to include additional readers for the `llama-index` library.

Dependency updates in the ingestion workflow:

* [`.github/workflows/ingest.yaml`](diffhunk://#diff-6c33d2698872942f3739917f555680ef7bdebbb058fd85fa9e1b552c631d90ebL23-R24): Replaced the installation of `llama-index` with `llama-index-readers-code` and `llama-index-readers-file` to support additional data ingestion capabilities.