### PR TITLE
Update Python version to 3.13 and adjust dependency installation

### DIFF
--- a/.github/workflows/ingest.yaml
+++ b/.github/workflows/ingest.yaml
@@ -15,13 +15,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install llama-index-readers-code
-          pip install llama-index-readers-file
+          pip install llama-index llama-cloud-services
 
       - name: Run ingestion script 
         env:


### PR DESCRIPTION
This pull request updates the Python version and modifies the dependencies used in the ingestion workflow. The changes ensure compatibility with newer Python versions and consolidate the dependencies for simplicity.

Workflow updates:

* [`.github/workflows/ingest.yaml`](diffhunk://#diff-6c33d2698872942f3739917f555680ef7bdebbb058fd85fa9e1b552c631d90ebL18-R23): Updated the Python version from `3.8` to `3.13` to use the latest Python features and improvements.
* [`.github/workflows/ingest.yaml`](diffhunk://#diff-6c33d2698872942f3739917f555680ef7bdebbb058fd85fa9e1b552c631d90ebL18-R23): Replaced individual `llama-index-readers-code` and `llama-index-readers-file` dependencies with `llama-index` and `llama-cloud-services` for a more streamlined dependency setup.